### PR TITLE
Update hdp.repo to use HDP 2.2 GA, puppet script fixes

### DIFF
--- a/files/repos/hdp.repo
+++ b/files/repos/hdp.repo
@@ -1,9 +1,9 @@
-#VERSION_NUMBER=2.2.0.0-1740
-[HDP-2.2.0.0-1740]
-name=Hortonworks Data Platform Version - HDP-2.2.0.0-1740
-baseurl=http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos6/2.x/BUILDS/2.2.0.0-1740
-gpgcheck=0
-gpgkey=http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos6/2.x/BUILDS/2.2.0.0-1740/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+#VERSION_NUMBER=2.2.0.0-2041
+[HDP-2.2.0.0]
+name=Hortonworks Data Platform Version - HDP-2.2.0.0
+baseurl=http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos6/2.x/updates/2.2.0.0
+gpgcheck=1
+gpgkey=http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos6/2.x/updates/2.2.0.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
 enabled=1
 priority=1
 

--- a/modules/hdfs_client/manifests/init.pp
+++ b/modules/hdfs_client/manifests/init.pp
@@ -77,6 +77,7 @@ class hdfs_client {
     ensure => 'link',
     target => "${conf_dir}",
     require => Package["hadoop_${rpm_version}"],
+    force => true
   }
 
   file { "${conf_dir}/commons-logging.properties":

--- a/modules/hive_client/manifests/init.pp
+++ b/modules/hive_client/manifests/init.pp
@@ -32,6 +32,7 @@ class hive_client {
     ensure => 'link',
     target => '/etc/hive/hdp',
     require => Package["hive_${rpm_version}"],
+    force => true
   }
 
   file { '/etc/hive/hdp/hive-env.sh':

--- a/modules/pig_client/manifests/init.pp
+++ b/modules/pig_client/manifests/init.pp
@@ -35,6 +35,7 @@ class pig_client {
     ensure => 'link',
     target => "${conf_dir}",
     require => Package["pig_${rpm_version}"],
+    force => true
   }
 
   file { "${conf_dir}/pig-env.sh":

--- a/modules/tez_client/manifests/init.pp
+++ b/modules/tez_client/manifests/init.pp
@@ -33,6 +33,7 @@ class tez_client {
   file { '/etc/tez/conf':
     ensure => 'link',
     target => "${conf_dir}",
+    force => true
   }
 
   file { "${conf_dir}/tez-env.sh":

--- a/modules/zookeeper_client/manifests/init.pp
+++ b/modules/zookeeper_client/manifests/init.pp
@@ -45,6 +45,7 @@ class zookeeper_client {
     ensure => 'link',
     target => "${conf_dir}",
     require => Package["zookeeper_${rpm_version}"],
+    force => true
   }
 
 


### PR DESCRIPTION
Add force option when creating conf directory symlinks. This just
overwrites template conf files under /etc/<project-name>/conf/

It looks like RPM are leaving the template conf files during installation.