### PR TITLE
Use the vagrant-cachier plugin if installed to speed up cluster setup.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,10 @@ hdp_version = findVersion()
 rpm_version = hdp_version.gsub /[.-]/, '_'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  if Vagrant.has_plugin?("vagrant-cachier")
+    # Configure cached packages to be shared between instances of the same base box.
+    config.cache.scope = :box
+  end
 
   # All Vagrant configuration is done here. The most common configuration
   # Every Vagrant virtual environment requires a box to build off of.


### PR DESCRIPTION
Plugin reference: https://github.com/fgrehm/vagrant-cachier

The plugin can be installed with 'vagrant plugin install
vagrant-cachier'. Speeds up 3-node cluster creation almost 3x.