### PR TITLE
Using non-volatile data directories so installs survive reboots.

### DIFF
--- a/files/init.d/hadoop-hdfs-datanode
+++ b/files/init.d/hadoop-hdfs-datanode
@@ -71,7 +71,7 @@ else
   TARGET_USER=${HADOOP_DATANODE_USER:-hdfs}
 fi
 
-install -d -m 0755 -o hdfs -g hdfs /var/run/hadoop-hdfs 1>/dev/null 2>&1 || :
+install -d -m 0755 -o hdfs -g hdfs /var/lib/hadoop-hdfs 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 start() {
   [ -x $EXEC_PATH ] || exit $ERROR_PROGRAM_NOT_INSTALLED

--- a/files/init.d/hadoop-hdfs-namenode
+++ b/files/init.d/hadoop-hdfs-namenode
@@ -65,7 +65,7 @@ USER="$SVC_USER"
 . $CONF_DIR/hadoop-env.sh
 PIDFILE="$HADOOP_PID_DIR/hadoop-$HADOOP_IDENT_STRING-namenode.pid"
 
-install -d -m 0755 -o hdfs -g hdfs /var/run/hadoop-hdfs 1>/dev/null 2>&1 || :
+install -d -m 0755 -o hdfs -g hdfs /var/lib/hadoop-hdfs 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 
 start() {

--- a/files/init.d/hadoop-mapreduce-historyserver
+++ b/files/init.d/hadoop-mapreduce-historyserver
@@ -65,7 +65,7 @@ USER=$SVC_USER
 . $CONF_DIR/mapred-env.sh
 PIDFILE="$HADOOP_PID_DIR/mapred-$HADOOP_MAPRED_IDENT_STRING-historyserver.pid"
 
-install -d -m 0755 -o mapred -g mapred /var/run/hadoop-mapreduce 1>/dev/null 2>&1 || :
+install -d -m 0755 -o mapred -g mapred /var/lib/hadoop-mapreduce 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 
 start() {

--- a/files/init.d/hadoop-yarn-nodemanager
+++ b/files/init.d/hadoop-yarn-nodemanager
@@ -65,7 +65,7 @@ USER=$SVC_USER
 . $CONF_DIR/yarn-env.sh
 PIDFILE="$HADOOP_PID_DIR/yarn-$YARN_IDENT_STRING-nodemanager.pid"
 
-install -d -m 0755 -o yarn -g yarn /var/run/hadoop-yarn 1>/dev/null 2>&1 || :
+install -d -m 0755 -o yarn -g yarn /var/lib/hadoop-yarn 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 
 start() {

--- a/files/init.d/hadoop-yarn-resourcemanager
+++ b/files/init.d/hadoop-yarn-resourcemanager
@@ -65,7 +65,7 @@ USER=$SVC_USER
 . $CONF_DIR/yarn-env.sh
 PIDFILE="$HADOOP_PID_DIR/yarn-$YARN_IDENT_STRING-resourcemanager.pid"
 
-install -d -m 0755 -o yarn -g yarn /var/run/hadoop-yarn 1>/dev/null 2>&1 || :
+install -d -m 0755 -o yarn -g yarn /var/lib/hadoop-yarn 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 
 start() {

--- a/modules/hdfs_client/manifests/init.pp
+++ b/modules/hdfs_client/manifests/init.pp
@@ -21,7 +21,7 @@ class hdfs_client {
   $conf_dir="/etc/hadoop/hdp"
   $path="${jdk::HOME}/bin:/bin:/usr/bin"
   $log_dir="/var/log/hadoop"
-  $data_dir="/var/run/hadoop"
+  $data_dir="/var/lib/hadoop"
   $pid_dir="/var/run/pid"
   $keytab_dir="/etc/security/hadoop"
 

--- a/modules/hive_meta/templates/hive-metastore.erb
+++ b/modules/hive_meta/templates/hive-metastore.erb
@@ -67,7 +67,7 @@ LOCKDIR="/var/lock/subsys"
 LOCKFILE="$LOCKDIR/hive-metastore"
 WORKING_DIR="/var/lib/hive"
 
-install -d -m 0755 -o hive -g hive /var/run/hive 1>/dev/null 2>&1 || :
+install -d -m 0755 -o hive -g hive /var/lib/hive 1>/dev/null 2>&1 || :
 [ -d "$LOCKDIR" ] || install -d -m 0755 $LOCKDIR 1>/dev/null 2>&1 || :
 start() {
     [ -x $EXE_FILE ] || exit $ERROR_PROGRAM_NOT_INSTALLED

--- a/modules/zookeeper_client/manifests/init.pp
+++ b/modules/zookeeper_client/manifests/init.pp
@@ -20,7 +20,7 @@ class zookeeper_client {
 
   $conf_dir="/etc/zookeeper/hdp"
   $log_dir="/var/log/zookeeper"
-  $data_dir="/var/run/zookeeper"
+  $data_dir="/var/lib/zookeeper"
   $pid_dir="/var/run/pid/zookeeper"
   $path="/usr/bin"
 


### PR DESCRIPTION
I noticed that following `vagrant reload` that the hdfs, namenode, and
datanode services would not start. This is due to the data dir being
created within /var/run, which is mounted on a volatile filesystem. As a
result, not only will data be lost during a `vagrant reload`, but the
directory structure created during `hdsf namenode -format` is lost. This
prevents the namenode service from starting, which in turn prevents the
datanode service from starting.

[jmaron found this same issue](https://github.com/hortonworks/structor/issues/5), and the change here
fixes it, I believe, by moving the data directories to /var/lib, which
is non-volatile.