### PR TITLE
Perform MySQL secure installation in temp directory.

### DIFF
--- a/modules/hive_db/manifests/init.pp
+++ b/modules/hive_db/manifests/init.pp
@@ -26,9 +26,10 @@ class hive_db {
   }
   ->
   exec { "secure-mysqld":
-    command => "mysql_secure_installation < files/secure-mysql.txt",
+    command => "mysql_secure_installation < /vagrant/modules/hive_db/files/secure-mysql.txt",
     path => "${PATH}",
-    cwd => "/vagrant/modules/hive_db",
+    cwd => "/tmp",
+    onlyif => "mysql -u root -e ';'",
   }
   ->
   exec { "add-remote-root":


### PR DESCRIPTION
When the VirtualBox host is Windows, a file created in the Vagrant directory may be world-writable.  MySQL Server ignores world-writable files, and hence the temporary configuration file containing the new root password. This causes following commands to fail.  Create the temporary configuration
file in /tmp to avoid this.

Also adds a test to ensure idempotency of the command.