### PR TITLE
Simple role for Spark 1.x

### DIFF
--- a/environments/structor/manifests/site.pp
+++ b/environments/structor/manifests/site.pp
@@ -46,6 +46,9 @@ if hasrole($roles, 'client') {
   if hasrole($clients, 'hbase') {
     include hbase_client
   }
+  if hasrole($clients, 'spark') {
+    include spark_client
+  }
   if hasrole($clients, 'hdfs') {
     include hdfs_client
   }

--- a/modules/spark_client/manifests/init.pp
+++ b/modules/spark_client/manifests/init.pp
@@ -1,0 +1,22 @@
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+class spark_client {
+  require hdfs_client
+
+  package { "spark${package_version}":
+    ensure => installed,
+  }
+}

--- a/profiles/1node-nonsecure.profile
+++ b/profiles/1node-nonsecure.profile
@@ -5,7 +5,7 @@
   "vm_mem": 3072,
   "server_mem": 300,
   "client_mem": 200,
-  "clients" : [ "hdfs", "hive", "oozie", "pig", "tez", "yarn", "zk" ],
+  "clients" : [ "spark", "hdfs", "hive", "oozie", "pig", "tez", "yarn", "zk" ],
   "nodes": [
     {"hostname": "nn", "ip": "240.0.0.11",
      "roles": ["client", "hive-db", "hive-meta", "nn", "oozie", "slave",

--- a/profiles/3node-spark-nonsecure.profile
+++ b/profiles/3node-spark-nonsecure.profile
@@ -1,0 +1,14 @@
+{
+  "domain": "example.com",
+  "realm": "EXAMPLE.COM",
+  "security": false,
+  "vm_mem": 4072,
+  "server_mem": 3000,
+  "client_mem": 1000,
+  "clients" : [ "hdfs", "yarn", "spark" ],
+  "nodes": [
+    {"hostname": "spark",  "ip": "240.0.0.11", "roles": [ "nn", "yarn", "slave", "client" ]},
+    {"hostname": "slave1", "ip": "240.0.0.12", "roles": [ "slave", "client" ]},
+    {"hostname": "slave2", "ip": "240.0.0.13", "roles": [ "slave", "client" ]}
+  ]
+}


### PR DESCRIPTION
The default configuration are good.

Tested with running SparkPi on YARN

vagrant ssh
export MASTER=yarn
run-example SparkPi 10 10

